### PR TITLE
🔧 Added support for subcategories:

### DIFF
--- a/src/main/java/io/github/lost2705/fintrack/dto/SubcategoryDto.java
+++ b/src/main/java/io/github/lost2705/fintrack/dto/SubcategoryDto.java
@@ -1,0 +1,10 @@
+package io.github.lost2705.fintrack.dto;
+
+import lombok.Data;
+
+@Data
+public class SubcategoryDto {
+    private Long id;
+    private String name;
+    private Long categoryId;
+}

--- a/src/main/java/io/github/lost2705/fintrack/dto/SubcategoryRequest.java
+++ b/src/main/java/io/github/lost2705/fintrack/dto/SubcategoryRequest.java
@@ -1,0 +1,9 @@
+package io.github.lost2705.fintrack.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SubcategoryRequest(
+        @NotBlank(message = "Название обязательно") String name,
+        @NotNull(message = "ID категории обязателен") Long categoryId
+) {}

--- a/src/main/java/io/github/lost2705/fintrack/dto/SubcategoryResponse.java
+++ b/src/main/java/io/github/lost2705/fintrack/dto/SubcategoryResponse.java
@@ -1,0 +1,7 @@
+package io.github.lost2705.fintrack.dto;
+
+public record SubcategoryResponse(
+        Long id,
+        String name,
+        String categoryName
+) {}

--- a/src/main/java/io/github/lost2705/fintrack/mapper/SubcategoryMapper.java
+++ b/src/main/java/io/github/lost2705/fintrack/mapper/SubcategoryMapper.java
@@ -1,0 +1,50 @@
+package io.github.lost2705.fintrack.mapper;
+
+import io.github.lost2705.fintrack.dto.SubcategoryDto;
+import io.github.lost2705.fintrack.dto.SubcategoryRequest;
+import io.github.lost2705.fintrack.dto.SubcategoryResponse;
+import io.github.lost2705.fintrack.model.Category;
+import io.github.lost2705.fintrack.model.Subcategory;
+import io.github.lost2705.fintrack.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SubcategoryMapper {
+
+    private final CategoryRepository categoryRepository;
+
+    public SubcategoryDto toDto(SubcategoryRequest request) {
+        SubcategoryDto dto = new SubcategoryDto();
+        dto.setName(request.name());
+        dto.setCategoryId(request.categoryId());
+        return dto;
+    }
+
+    public SubcategoryDto toDto(Subcategory entity) {
+        SubcategoryDto dto = new SubcategoryDto();
+        dto.setId(entity.getId());
+        dto.setName(entity.getName());
+        dto.setCategoryId(entity.getCategory().getId());
+        return dto;
+    }
+
+    public Subcategory toEntity(SubcategoryDto dto) {
+        Subcategory entity = new Subcategory();
+        entity.setId(dto.getId());
+        entity.setName(dto.getName());
+        Category category = categoryRepository.findById(dto.getCategoryId())
+                .orElseThrow(() -> new IllegalArgumentException("Категория не найдена: id = " + dto.getCategoryId()));
+        entity.setCategory(category);
+        return entity;
+    }
+
+    public SubcategoryResponse toResponse(Subcategory entity) {
+        return new SubcategoryResponse(
+                entity.getId(),
+                entity.getName(),
+                entity.getCategory().getName()
+        );
+    }
+}

--- a/src/main/java/io/github/lost2705/fintrack/model/Subcategory.java
+++ b/src/main/java/io/github/lost2705/fintrack/model/Subcategory.java
@@ -1,0 +1,23 @@
+package io.github.lost2705.fintrack.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "subcategories")
+@Getter
+@Setter
+public class Subcategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "category_id")
+    private Category category;
+}


### PR DESCRIPTION
- Introduced `Subcategory` entity linked to `Category`
- Created `SubcategoryDto`, `SubcategoryRequest`, `SubcategoryResponse`
- Implemented `SubcategoryMapper` with manual mapping
- Ready for controller and service layer in the next step

This lays the groundwork for organizing transactions into finer-grained categories.