### PR TITLE
Added initial Telegram bot integration based on telegrambots-spring-b…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,15 +57,21 @@
 			<version>2.5.0</version>
 		</dependency>
 		<dependency>
-			<groupId>jakarta.validation</groupId>
-			<artifactId>jakarta.validation-api</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
 			<version>1.5.5.Final</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.telegram</groupId>
+            <artifactId>telegrambots-spring-boot-starter</artifactId>
+            <version>6.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/io/github/lost2705/fintrack/BotConfig.java
+++ b/src/main/java/io/github/lost2705/fintrack/BotConfig.java
@@ -1,0 +1,27 @@
+package io.github.lost2705.fintrack;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.telegram.telegrambots.meta.TelegramBotsApi;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
+
+@Configuration
+public class BotConfig {
+
+    @Bean
+    public TelegramBotsApi telegramBotsApi(FinTrackBot finTrackBot) throws TelegramApiException {
+        TelegramBotsApi botsApi = new TelegramBotsApi(DefaultBotSession.class);
+        try {
+            botsApi.registerBot(finTrackBot);
+        } catch (TelegramApiException e) {
+            // если ошибка только про "Error removing old webhook" / 404 — логируем и продолжаем
+            if (e.getMessage() != null && e.getMessage().contains("Error removing old webhook")) {
+                System.out.println("Webhook уже не настроен, продолжаем как long polling бот");
+            } else {
+                throw e;
+            }
+        }
+        return botsApi;
+    }
+}

--- a/src/main/java/io/github/lost2705/fintrack/FinTrackBot.java
+++ b/src/main/java/io/github/lost2705/fintrack/FinTrackBot.java
@@ -1,0 +1,47 @@
+package io.github.lost2705.fintrack;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+@Component
+public class FinTrackBot extends TelegramLongPollingBot {
+
+    @Value("${telegram.bot.username}")
+    private String botUsername;
+
+    @Value("${telegram.bot.token}")
+    private String botToken;
+
+    @Override
+    public String getBotUsername() {
+        return botUsername;
+    }
+
+    @Override
+    public String getBotToken() {
+        return botToken;
+    }
+
+    @Override
+    public void onUpdateReceived(Update update) {
+        System.out.println("Update: " + update); // или логгер
+
+        if (update.hasMessage() && update.getMessage().hasText()) {
+            String messageText = update.getMessage().getText();
+            Long chatId = update.getMessage().getChatId();
+
+            SendMessage message = new SendMessage(chatId.toString(), "Вы написали: " + messageText);
+
+            try {
+                execute(message);
+            } catch (TelegramApiException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,3 +15,8 @@ spring:
     show-sql: true
     flyway:
       enabled: true
+
+telegram:
+  bot:
+    username: your_bot_username
+    token: your_bot_token


### PR DESCRIPTION
…oot-starter.

Implemented FinTrackBot as a TelegramLongPollingBot that echoes incoming text messages.

Injected bot credentials via telegram.bot.username and telegram.bot.token properties.

Introduced BotConfig to register the bot manually with TelegramBotsApi for Spring Boot 3 compatibility.

Added Bean Validation support via spring-boot-starter-validation and cleaned up direct jakarta.validation-api usage.

Verified that the application starts successfully and the bot responds to user messages in Telegram chat.